### PR TITLE
Update package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "keywords": [
     "chai",
+    "chai-plugin",
+    "array",
     "bookshelf",
     "testing",
     "tests",


### PR DESCRIPTION
See https://github.com/chaijs/chai-docs/issues/34 for more.

> If you're wondering why I want you to add these keywords, here is the reasoning for each one:
> - `chai-plugin` will let us index your plugin on the next version of the website. If you don't add this to your package.json, you wont be listed on our plugins page.
> - `browser` will let us know that your plugin supports the browser. Please don't add this keyword if you don't support the browser. If you don't add it we'll assume the plugin does not support browsers.
> - Any other keyword listed below has been listed there, because it was in our plugins.js file which is soon to be removed. If you don't want these keywords in your package.json, that's fine, but seeing as they're in our plugins.js I thought it'd be good measure to give you a chance to add them into your package.json. We'll use them to help filter our plugins page, so it is advisable to add them.
